### PR TITLE
Fix config command related bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -114,20 +114,20 @@ The **GUI** is split up into 4 main sections.
 <box type="warning" seamless>
 
 **Caution:**
-Configuring Class Manager resets the class details (grades, attendance and class participation details) of all students. This **cannot** be undone. It is recommended to configure Class Manager before adding students.
+Configuring Class Manager resets the class details (grades, attendance and class participation details) of all students, as well as the past states of Class Manager. This **cannot** be undone using the `undo` command. It is recommended to configure Class Manager before adding students.
 </box>
 
 Before you begin using Class Manager, it is recommended that you configure the number of tutorials and assignments that your module has. This can be done using the `config` command, and allows Class Manager to automatically generate the correct number of class details fields for each student. <br><br>
-Class Manager can be configured _at any time_, but do take note of the warning above regarding **loss** of student data. If Class Manager is configured after adding students, each student will have the correct number of tutorials and assignments, but their class details data will be **reset**.
+Class Manager can be configured _at any time_, but do take note of the warning above regarding **loss** of student data and past Class Manager states. If you configure Class Manager after adding students, each student will have the correct number of tutorials and assignments. However, their class details data will be **reset** and there will be no previous states of Class Manager you can return to via the `undo` command.
 
 Format: `config #t/TUTORIAL_COUNT #a/ASSIGNMENT_COUNT`
 
-* `TUTORIAL_COUNT` and `ASSIGNMENT_COUNT` must be 0 or a positive integer.
+* `TUTORIAL_COUNT` and `ASSIGNMENT_COUNT` must be a positive integer between 1 and 40 inclusive.
 * Inputting the same `TUTORIAL_COUNT` or `ASSIGNMENT_COUNT` as the previous configuration will also **reset** the class details of all students.
 
 Examples:
 * `config #t/13 #a/1`
-* `config #a/4 #t/26`
+* `config #a/4 #t/39`
 
 ---
 

--- a/src/main/java/seedu/classmanager/logic/LogicManager.java
+++ b/src/main/java/seedu/classmanager/logic/LogicManager.java
@@ -62,16 +62,7 @@ public class LogicManager implements Logic {
             history.add(commandText);
         }
 
-        if (classManagerModified) {
-            logger.info("Class Manager modified, saving to file.");
-            try {
-                storage.saveClassManager(model.getClassManager(), model.getClassManagerFilePath());
-            } catch (AccessDeniedException e) {
-                throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
-            } catch (IOException ioe) {
-                throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
-            }
-        } else if (command instanceof LoadCommand | command instanceof ConfigCommand) {
+        if (command instanceof LoadCommand | command instanceof ConfigCommand) {
             try {
                 storage.saveClassManager(model.getClassManager(), model.getClassManagerFilePath());
                 storage.saveUserPrefs(model.getUserPrefs());
@@ -80,6 +71,15 @@ public class LogicManager implements Logic {
                 } else {
                     logger.info("Class Manager has been configured.");
                 }
+            } catch (AccessDeniedException e) {
+                throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
+            } catch (IOException ioe) {
+                throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+            }
+        } else if (classManagerModified) {
+            logger.info("Class Manager modified, saving to file.");
+            try {
+                storage.saveClassManager(model.getClassManager(), model.getClassManagerFilePath());
             } catch (AccessDeniedException e) {
                 throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
             } catch (IOException ioe) {

--- a/src/main/java/seedu/classmanager/logic/commands/ConfigCommand.java
+++ b/src/main/java/seedu/classmanager/logic/commands/ConfigCommand.java
@@ -65,6 +65,7 @@ public class ConfigCommand extends Command {
             ClassDetails.setAssignmentCount(assignmentCount);
             model.setTutorialCount(tutorialCount);
             model.setAssignmentCount(assignmentCount);
+
             // This will display the class details of the first student before the configuration is done
             model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
             List<Student> allStudentList = model.getFilteredStudentList();
@@ -74,6 +75,10 @@ public class ConfigCommand extends Command {
                         student.getStudentNumber(), newClassDetails, student.getTags(), student.getComment());
                 model.setStudent(student, editedStudent);
             }
+
+            // Reset the history of the model and prevent any undo commands
+            model.configReset();
+
             // This will display the class details of the first student after the configuration is done
             if (!allStudentList.isEmpty()) {
                 model.setSelectedStudent(allStudentList.get(0));

--- a/src/main/java/seedu/classmanager/logic/commands/LoadCommand.java
+++ b/src/main/java/seedu/classmanager/logic/commands/LoadCommand.java
@@ -34,7 +34,10 @@ public class LoadCommand extends Command {
     public static final String MESSAGE_FILE_NOT_FOUND = "The file %1$s.json cannot be found.\n"
             + "Please make sure the file is in the /data folder.\n";
     public static final String MESSAGE_FILE_CANNOT_LOAD = "The file %1$s.json cannot be loaded.\n"
-            + "Please make sure the file is formatted correctly.\n";
+            + "Please make sure the file is formatted correctly.\n"
+            + "The number of tutorials and assignments of each student in the file must match"
+            + " the current configuration of Class Manager.\n"
+            + "You can configure Class Manager before loading the file.";
 
     private final String fileName;
     private final Path filePath;

--- a/src/main/java/seedu/classmanager/logic/commands/LoadCommand.java
+++ b/src/main/java/seedu/classmanager/logic/commands/LoadCommand.java
@@ -73,7 +73,7 @@ public class LoadCommand extends Command {
             throw new CommandException(String.format(MESSAGE_FILE_CANNOT_LOAD, fileName));
         }
         model.setClassManagerFilePath(filePath);
-        model.reset(newData);
+        model.loadReset(newData);
 
         return new CommandResult(String.format(MESSAGE_LOAD_SUCCESS, fileName), false, false, true, false);
     }

--- a/src/main/java/seedu/classmanager/logic/parser/ConfigCommandParser.java
+++ b/src/main/java/seedu/classmanager/logic/parser/ConfigCommandParser.java
@@ -13,8 +13,13 @@ import seedu.classmanager.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new ConfigCommand object
  */
 public class ConfigCommandParser implements Parser<ConfigCommand> {
-    public static final String MESSAGE_INVALID_COUNT_VALUE_TOO_SMALL = "Invalid count value!"
-            + "The count value of %1$s cannot be less than 0.";
+    public static final String MESSAGE_INVALID_COUNT_VALUE_TOO_SMALL = "Invalid count values!"
+            + "The count value of %1$s cannot be less than 1.";
+    public static final String MESSAGE_INVALID_COUNT_VALUE_TOO_LARGE = "Invalid count values!"
+            + "The count value of %1$s cannot be more than 40.";
+    public static final String MESSAGE_INVALID_CONFIG_COMMAND_FORMAT = "Invalid count values! Please input an "
+            + "integer between 1 to 40 inclusive for both tutorial count and assignment count."
+            + "\n%1$s";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ConfigCommand
@@ -38,7 +43,7 @@ public class ConfigCommandParser implements Parser<ConfigCommand> {
             tutorialCount = Integer.parseInt(argMultimap.getValue(PREFIX_TUTORIAL_COUNT).get());
             assignmentCount = Integer.parseInt(argMultimap.getValue(PREFIX_ASSIGNMENT_COUNT).get());
         } catch (NumberFormatException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_CONFIG_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
         }
         validCountParser(tutorialCount, "tutorials");
         validCountParser(assignmentCount, "assignments");
@@ -52,8 +57,10 @@ public class ConfigCommandParser implements Parser<ConfigCommand> {
      * @throws ParseException if the count value is less than 0.
      */
     private void validCountParser(int count, String attribute) throws ParseException {
-        if (count < 0) {
+        if (count < 1) {
             throw new ParseException(String.format(MESSAGE_INVALID_COUNT_VALUE_TOO_SMALL, attribute));
+        } else if (count > 40) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COUNT_VALUE_TOO_LARGE, attribute));
         }
     }
 }

--- a/src/main/java/seedu/classmanager/model/Model.java
+++ b/src/main/java/seedu/classmanager/model/Model.java
@@ -150,12 +150,17 @@ public interface Model {
      * Saves the current Class Manager state for undo/redo.
      */
     void commitClassManager();
+    //@@author
 
     /**
      * Resets the history of the model after a load command.
      */
-    void reset(ReadOnlyClassManager classManager);
-    //@@author
+    void loadReset(ReadOnlyClassManager classManager);
+
+    /**
+     * Resets the history of the model after a config command.
+     */
+    void configReset();
 
     /**
      * Resets the selected student after a clear command.

--- a/src/main/java/seedu/classmanager/model/ModelManager.java
+++ b/src/main/java/seedu/classmanager/model/ModelManager.java
@@ -217,16 +217,24 @@ public class ModelManager implements Model {
     public void commitClassManager() {
         versionedClassManager.commit();
     }
+    //@@author
 
     /**
      * Resets the history of the model after a load command.
      */
     @Override
-    public void reset(ReadOnlyClassManager classManager) {
-        this.versionedClassManager.reset(classManager);
+    public void loadReset(ReadOnlyClassManager classManager) {
+        this.versionedClassManager.loadReset(classManager);
         versionedClassManager.resetSelectedStudent();
     }
-    //@@author
+
+    /**
+     * Resets the history of the model after a config command.
+     */
+    @Override
+    public void configReset() {
+        this.versionedClassManager.configReset();
+    }
 
     /**
      * Resets the selected student after a clear command.

--- a/src/main/java/seedu/classmanager/model/VersionedClassManager.java
+++ b/src/main/java/seedu/classmanager/model/VersionedClassManager.java
@@ -43,7 +43,7 @@ public class VersionedClassManager extends ClassManager {
     }
 
     /**
-     * Removes all states other than the current state.
+     * Resets class manager after a load command.
      */
     public void loadReset(ReadOnlyClassManager newData) {
         classManagerStateList.clear();
@@ -53,11 +53,16 @@ public class VersionedClassManager extends ClassManager {
     }
 
     /**
-     * Removes all states other than the current state.
+     * Removes all states other than the current state after a config command.
      */
     public void configReset() {
+        // Removes all states before the current state, if any
         if (currentStatePointer > 0) {
-            classManagerStateList.subList(0, classManagerStateList.size() - 2).clear();
+            classManagerStateList.subList(0, currentStatePointer).clear();
+        }
+        // Removes all states after the current state, if any
+        if (classManagerStateList.size() > 1) {
+            classManagerStateList.subList(1, classManagerStateList.size()).clear();
         }
         currentStatePointer = 0;
     }

--- a/src/main/java/seedu/classmanager/model/VersionedClassManager.java
+++ b/src/main/java/seedu/classmanager/model/VersionedClassManager.java
@@ -45,11 +45,21 @@ public class VersionedClassManager extends ClassManager {
     /**
      * Removes all states other than the current state.
      */
-    public void reset(ReadOnlyClassManager newData) {
+    public void loadReset(ReadOnlyClassManager newData) {
         classManagerStateList.clear();
         classManagerStateList.add(newData);
         currentStatePointer = 0;
         resetData(classManagerStateList.get(currentStatePointer));
+    }
+
+    /**
+     * Removes all states other than the current state.
+     */
+    public void configReset() {
+        if (currentStatePointer > 0) {
+            classManagerStateList.subList(0, classManagerStateList.size() - 2).clear();
+        }
+        currentStatePointer = 0;
     }
 
     /**

--- a/src/main/java/seedu/classmanager/model/student/ClassDetails.java
+++ b/src/main/java/seedu/classmanager/model/student/ClassDetails.java
@@ -20,16 +20,16 @@ import seedu.classmanager.storage.JsonAdaptedClassDetails;
 public class ClassDetails {
 
     public static final String MESSAGE_CONSTRAINTS = "Class number should be in the form 'T[Integer]',"
-            + " such as 'T11'";
-    public static final String MESSAGE_INVALID_GRADE = "Grade should be an integer between 0 and 100";
+            + " such as 'T11'.";
+    public static final String MESSAGE_INVALID_GRADE = "Grade should be an integer between 0 and 100 inclusive.";
     public static final String MESSAGE_INVALID_ASSIGNMENT_NUMBER = "Assignment index should be an integer "
-            + "between 1 and %s";
+            + "between 1 and %s.";
 
     public static final String MESSAGE_INVALID_PARTICIPATION = "Participation should be "
-            + "either 'true' or 'false'";
+            + "either 'true' or 'false'.";
     public static final String MESSAGE_INVALID_TUTORIAL_INDEX = "Tutorial index should be an "
             + "integer(without decimal places) "
-            + "between 1 and %s";
+            + "between 1 and %s.";
     public static final String MESSAGE_UNEQUAL_LENGTH = "The number of tutorial sessions and "
             + "attendance records should be equal.";
     public static final String MESSAGE_RECONFIGURE = " Please reconfigure Class Manager before "

--- a/src/main/java/seedu/classmanager/model/student/Comment.java
+++ b/src/main/java/seedu/classmanager/model/student/Comment.java
@@ -10,7 +10,7 @@ import static seedu.classmanager.commons.util.AppUtil.checkArgument;
 public class Comment {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Comments can contain any alphanumeric characters";
+            "Comments can contain any alphanumeric characters.";
 
     /*
      * The first character of the classmanager must not be a whitespace,

--- a/src/main/java/seedu/classmanager/model/student/Name.java
+++ b/src/main/java/seedu/classmanager/model/student/Name.java
@@ -10,7 +10,7 @@ import static seedu.classmanager.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank.";
 
     /*
      * The first character of the classmanager must not be a whitespace,

--- a/src/main/java/seedu/classmanager/model/student/Phone.java
+++ b/src/main/java/seedu/classmanager/model/student/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should be a positive integer. The number should be 3 to 20 digits long.";
+    public static final String VALIDATION_REGEX = "\\d{3,20}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/classmanager/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/classmanager/logic/LogicManagerTest.java
@@ -360,7 +360,7 @@ public class LogicManagerTest {
         }
         ModelManager expectedModel = new ModelManager();
         expectedModel.setClassManagerFilePath(filePath);
-        expectedModel.reset(newData);
+        expectedModel.loadReset(newData);
         assertCommandFailure(loadCommand, CommandException.class, expectedMessage, expectedModel);
         assertHistoryCorrect(loadCommand);
     }

--- a/src/test/java/seedu/classmanager/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/classmanager/logic/commands/AddCommandTest.java
@@ -229,11 +229,15 @@ public class AddCommandTest {
         }
 
         @Override
-        public void reset(ReadOnlyClassManager classManager) {
+        public void loadReset(ReadOnlyClassManager classManager) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void configReset() {
             throw new AssertionError("This method should not be called.");
         }
         //@@author
-
         @Override
         public void resetSelectedStudent() {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/classmanager/logic/commands/LoadCommandTest.java
+++ b/src/test/java/seedu/classmanager/logic/commands/LoadCommandTest.java
@@ -74,7 +74,7 @@ public class LoadCommandTest {
             throw new CommandException(String.format(MESSAGE_FILE_CANNOT_LOAD, fileName));
         }
         expectedModel.setClassManagerFilePath(filePath);
-        expectedModel.reset(tempData);
+        expectedModel.loadReset(tempData);
     }
 
     @Test

--- a/src/test/java/seedu/classmanager/logic/parser/ConfigCommandParserTest.java
+++ b/src/test/java/seedu/classmanager/logic/parser/ConfigCommandParserTest.java
@@ -8,6 +8,8 @@ import static seedu.classmanager.logic.parser.CliSyntax.PREFIX_TUTORIAL_COUNT;
 import static seedu.classmanager.logic.parser.CliSyntax.PREFIX_WILDCARD;
 import static seedu.classmanager.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.classmanager.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.classmanager.logic.parser.ConfigCommandParser.MESSAGE_INVALID_CONFIG_COMMAND_FORMAT;
+import static seedu.classmanager.logic.parser.ConfigCommandParser.MESSAGE_INVALID_COUNT_VALUE_TOO_LARGE;
 import static seedu.classmanager.logic.parser.ConfigCommandParser.MESSAGE_INVALID_COUNT_VALUE_TOO_SMALL;
 
 import org.junit.jupiter.api.Test;
@@ -20,7 +22,7 @@ public class ConfigCommandParserTest {
 
     @Test
     public void parse_validArg_success() {
-        int tutorialCount = 3;
+        int tutorialCount = 1;
         int assignmentCount = 2;
         ConfigCommand expectedCommand = new ConfigCommand(tutorialCount, assignmentCount);
         String argument = " " + PREFIX_TUTORIAL_COUNT + tutorialCount + " "
@@ -30,8 +32,8 @@ public class ConfigCommandParserTest {
 
     @Test
     public void parse_validArg2_success() {
-        int tutorialCount = 1;
-        int assignmentCount = 0;
+        int tutorialCount = 40;
+        int assignmentCount = 39;
         ConfigCommand expectedCommand = new ConfigCommand(tutorialCount, assignmentCount);
         String argument = " " + PREFIX_ASSIGNMENT_COUNT + assignmentCount + " "
                 + PREFIX_TUTORIAL_COUNT + tutorialCount;
@@ -40,17 +42,54 @@ public class ConfigCommandParserTest {
 
     @Test
     public void parse_nonIntArg_failure() {
-        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "a "
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "1 "
                 + PREFIX_TUTORIAL_COUNT + "t";
         assertParseFailure(parser, argument, String.format(
-                MESSAGE_INVALID_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_CONFIG_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_negativeIntArg_failure() {
-        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "-1 "
+    public void parse_nonIntArg2_failure() {
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "1.4 "
+                + PREFIX_TUTORIAL_COUNT + "1";
+        assertParseFailure(parser, argument, String.format(
+                MESSAGE_INVALID_CONFIG_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_intOverflowArg_failure() {
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "42984732998379823983289733332332 "
                 + PREFIX_TUTORIAL_COUNT + "2";
+        assertParseFailure(parser, argument,
+                String.format(MESSAGE_INVALID_CONFIG_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_tooSmallIntArg_failure() {
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "0 "
+                + PREFIX_TUTORIAL_COUNT + "1";
         assertParseFailure(parser, argument, String.format(MESSAGE_INVALID_COUNT_VALUE_TOO_SMALL, "assignments"));
+    }
+
+    @Test
+    public void parse_tooSmallIntArg2_failure() {
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "1 "
+                + PREFIX_TUTORIAL_COUNT + "-4";
+        assertParseFailure(parser, argument, String.format(MESSAGE_INVALID_COUNT_VALUE_TOO_SMALL, "tutorials"));
+    }
+
+    @Test
+    public void parse_tooLargeIntArg_failure() {
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "41 "
+                + PREFIX_TUTORIAL_COUNT + "1";
+        assertParseFailure(parser, argument, String.format(MESSAGE_INVALID_COUNT_VALUE_TOO_LARGE, "assignments"));
+    }
+
+    @Test
+    public void parse_tooLargeIntArg2_failure() {
+        String argument = " " + PREFIX_ASSIGNMENT_COUNT + "1 "
+                + PREFIX_TUTORIAL_COUNT + "41";
+        assertParseFailure(parser, argument, String.format(MESSAGE_INVALID_COUNT_VALUE_TOO_LARGE, "tutorials"));
     }
 
     @Test
@@ -58,7 +97,7 @@ public class ConfigCommandParserTest {
         String argument = " " + PREFIX_ASSIGNMENT_COUNT + " "
                 + PREFIX_TUTORIAL_COUNT + "2";
         assertParseFailure(parser, argument, String.format(
-                MESSAGE_INVALID_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_CONFIG_COMMAND_FORMAT, ConfigCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/classmanager/model/VersionedClassManagerTest.java
+++ b/src/test/java/seedu/classmanager/model/VersionedClassManagerTest.java
@@ -321,5 +321,73 @@ public class VersionedClassManagerTest {
         // different value -> returns false;
         assertFalse(versionedClassManager.equals(newVersionedClassManager));
     }
+    //@@author
+
+    @Test
+    public void configReset_stateOneOfOne_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager);
+
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(emptyClassManager));
+    }
+
+    @Test
+    public void configReset_stateTwoOfTwo_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager, classManagerWithAmy);
+
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(classManagerWithAmy));
+    }
+
+    @Test
+    public void configReset_stateThreeOfThree_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager, classManagerWithAmy,
+                classManagerWithBob);
+
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(classManagerWithBob));
+    }
+
+    @Test
+    public void configReset_stateFourOfFour_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager, classManagerWithAmy,
+                classManagerWithBob, classManagerWithCarl);
+
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(classManagerWithCarl));
+    }
+
+    @Test
+    public void configReset_stateOneOfFour_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager, classManagerWithAmy,
+                classManagerWithBob, classManagerWithCarl);
+
+        versionedClassManager.undo();
+        versionedClassManager.undo();
+        versionedClassManager.undo();
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(emptyClassManager));
+    }
+
+    @Test
+    public void configReset_stateTwoOfFour_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager, classManagerWithAmy,
+                classManagerWithBob, classManagerWithCarl);
+
+        versionedClassManager.undo();
+        versionedClassManager.undo();
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(classManagerWithAmy));
+    }
+
+    @Test
+    public void configReset_stateThreeOfFour_success() {
+        VersionedClassManager versionedClassManager = prepareClassManagerList(emptyClassManager, classManagerWithAmy,
+                classManagerWithBob, classManagerWithCarl);
+
+        versionedClassManager.undo();
+        versionedClassManager.configReset();
+        assertEquals(versionedClassManager, new VersionedClassManager(classManagerWithBob));
+    }
 }
-//@@author
+

--- a/src/test/java/seedu/classmanager/model/student/PhoneTest.java
+++ b/src/test/java/seedu/classmanager/model/student/PhoneTest.java
@@ -31,11 +31,12 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("123456789012345678901")); // 21-digit phone number
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("12345678901234567890")); // 20-digit phone number
     }
 
     @Test


### PR DESCRIPTION
Config command now resets the state of Class Manager and prevents users from using the undo command to reach a state before Class Manager was configured. 

Config command now only allows for tutorial and assignment counts to be between 1 to 40 inclusive. This fixes division by zero errors for class details data visualisation, as well as prevents the app from freezing or crashing when the count is too large.

Correct error messages are now shown for non integer input parameters.